### PR TITLE
feat: dsn fetcher support multiple object fetchers

### DIFF
--- a/docker/file-retriever/docker-compose.yml
+++ b/docker/file-retriever/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - '8090:8090'
     environment:
       - NODE_ENV=production
-      - SUBSPACE_GATEWAY_URL=http://subspace-http-gateway:8080
+      - SUBSPACE_GATEWAY_URLS=http://subspace-http-gateway:8080
       - CORS_ORIGIN=${CORS_ORIGIN}
       - MAX_SIMULTANEOUS_FETCHES=${MAX_SIMULTANEOUS_FETCHES}
       - CACHE_DIR=${CACHE_DIR}

--- a/services/file-retriever/src/config.ts
+++ b/services/file-retriever/src/config.ts
@@ -6,7 +6,7 @@ const ONE_DAY = 24 * 60 * 60 * 1000
 export const config = {
   // Required
   apiSecret: env('API_SECRET'),
-  subspaceGatewayUrl: env('SUBSPACE_GATEWAY_URL'),
+  subspaceGatewayUrls: env('SUBSPACE_GATEWAY_URLS'),
   // Optional
   logLevel: env('LOG_LEVEL', { defaultValue: 'info' }),
   port: Number(env('FILE_RETRIEVER_PORT', { defaultValue: 8090 })),


### PR DESCRIPTION
As I measured during benchmarking multiple fetchers improves the download bandwidth of the auto-files gateway. This PR updates DSN object fetcher to enable the usage several object fetchers.