### PR TITLE
fix: environment variable value treated as unknown 

### DIFF
--- a/services/file-retriever/src/config.ts
+++ b/services/file-retriever/src/config.ts
@@ -6,7 +6,7 @@ const ONE_DAY = 24 * 60 * 60 * 1000
 export const config = {
   // Required
   apiSecret: env('API_SECRET'),
-  subspaceGatewayUrls: env('SUBSPACE_GATEWAY_URLS'),
+  subspaceGatewayUrls: env<string>('SUBSPACE_GATEWAY_URLS'),
   // Optional
   logLevel: env('LOG_LEVEL', { defaultValue: 'info' }),
   port: Number(env('FILE_RETRIEVER_PORT', { defaultValue: 8090 })),


### PR DESCRIPTION
The `config.subspaceGatewayUrls` was treated as unknown leading to a build error. 