### PR TITLE
Fix sqlite cache

### DIFF
--- a/services/file-retriever/src/config.ts
+++ b/services/file-retriever/src/config.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import { env } from './utils/env.js'
 
 const TEN_GB = 10 * 1024 ** 3
@@ -16,7 +17,10 @@ export const config = {
       defaultValue: 10,
     }),
   ),
-  cacheDir: env('CACHE_DIR', { defaultValue: './.cache' }),
+  cacheDir: path.join(
+    process.cwd(),
+    env('CACHE_DIR', { defaultValue: './.cache' }),
+  ),
   cacheMaxSize: Number(
     env('CACHE_MAX_SIZE', {
       defaultValue: TEN_GB,

--- a/services/file-retriever/src/services/fileCache/index.ts
+++ b/services/file-retriever/src/services/fileCache/index.ts
@@ -14,8 +14,6 @@ type FileCacheEntry = Omit<FileResponse, 'data'>
 type UncheckedFileCacheEntry = FileCacheEntry | null | undefined
 
 export const createFileCache = (config: BaseCacheConfig) => {
-  fs.mkdirSync(config.cacheDir, { recursive: true })
-
   const cidToFilePath = (cid: string) => {
     const partitions = config.pathPartitions
 

--- a/services/file-retriever/src/services/fileComposer.ts
+++ b/services/file-retriever/src/services/fileComposer.ts
@@ -9,9 +9,10 @@ import path from 'path'
 import KeyvSqlite from '@keyvhq/sqlite'
 import { config } from '../config.js'
 import { logger } from '../drivers/logger.js'
+import { ensureDirectoryExists } from '../utils/fs.js'
 
 const cache = createFileCache({
-  cacheDir: path.join(config.cacheDir, 'files'),
+  cacheDir: ensureDirectoryExists(path.join(config.cacheDir, 'files')),
   pathPartitions: 3,
   stores: [
     new Keyv({
@@ -27,7 +28,7 @@ const cache = createFileCache({
     }),
     new Keyv({
       store: new KeyvSqlite({
-        uri: path.join(config.cacheDir, 'files.sqlite'),
+        uri: path.join(ensureDirectoryExists(config.cacheDir), 'files.sqlite'),
       }),
       ttl: config.cacheTtl,
       serialize: stringify,

--- a/services/file-retriever/src/utils/fs.ts
+++ b/services/file-retriever/src/utils/fs.ts
@@ -1,4 +1,5 @@
 import fsPromises from 'fs/promises'
+import fs from 'fs'
 import path from 'path'
 
 export const writeFile = async (
@@ -14,4 +15,14 @@ export const writeFile = async (
 
   await fsPromises.writeFile(tempFilePath, data)
   await fsPromises.rename(tempFilePath, filepath)
+}
+
+export const ensureDirectoryExists = (dir: string) => {
+  fs.mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+export const asyncEnsureDirectoryExists = async (dir: string) => {
+  await fsPromises.mkdir(dir, { recursive: true })
+  return dir
 }

--- a/services/file-retriever/src/utils/fs.ts
+++ b/services/file-retriever/src/utils/fs.ts
@@ -21,8 +21,3 @@ export const ensureDirectoryExists = (dir: string) => {
   fs.mkdirSync(dir, { recursive: true })
   return dir
 }
-
-export const asyncEnsureDirectoryExists = async (dir: string) => {
-  await fsPromises.mkdir(dir, { recursive: true })
-  return dir
-}


### PR DESCRIPTION
In prod environments SQLITE caching was not working since the target directory didn't exists. This update ensures the existence of the directory when referred. 

I choose the sync option because it's only used on startup so the burden is not significant and no async management should be done. 