### PR TITLE
Handling errors thrown in handler's async context 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "indexer": "yarn workspace object-mapping-indexer",
     "file-retriever": "yarn workspace file-retriever",
-    "benchmark": "node --loader ts-node/esm benchmarks/taurus.ts"
+    "benchmark": "node --loader ts-node/esm benchmarks/taurus.ts",
+    "build": "yarn workspaces foreach --all run build"
   },
   "dependencies": {
     "axios": "^1.7.9",

--- a/services/file-retriever/package.json
+++ b/services/file-retriever/package.json
@@ -20,6 +20,7 @@
     "cpu-features": "^0.0.10",
     "dotenv": "^16.4.7",
     "express": "^4.21.1",
+    "express-async-errors": "^3.1.1",
     "keyv": "^5.2.1",
     "lru-cache": "^11.0.2",
     "mime-types": "^2.1.35",

--- a/services/file-retriever/src/http/controllers/file.ts
+++ b/services/file-retriever/src/http/controllers/file.ts
@@ -3,11 +3,14 @@ import { authMiddleware } from '../middlewares/auth.js'
 import { fileComposer } from '../../services/fileComposer.js'
 import { pipeline } from 'stream'
 import { logger } from '../../drivers/logger.js'
+import { asyncSafeHandler } from '../../utils/express.js'
 
 const fileRouter = Router()
 
-fileRouter.get('/:cid', authMiddleware, async (req, res, next) => {
-  try {
+fileRouter.get(
+  '/:cid',
+  authMiddleware,
+  asyncSafeHandler(async (req, res) => {
     logger.debug(`Fetching file ${req.params.cid} from ${req.ip}`)
 
     const cid = req.params.cid
@@ -44,9 +47,7 @@ fileRouter.get('/:cid', authMiddleware, async (req, res, next) => {
         })
       }
     })
-  } catch (err) {
-    next(err)
-  }
-})
+  }),
+)
 
 export { fileRouter }

--- a/services/file-retriever/src/http/controllers/node.ts
+++ b/services/file-retriever/src/http/controllers/node.ts
@@ -2,21 +2,25 @@ import { Router } from 'express'
 import { dsnFetcher } from '../../services/dsnFetcher.js'
 import { cidToString } from '@autonomys/auto-dag-data'
 import { safeIPLDDecode } from '../../utils/dagData.js'
+import { asyncSafeHandler } from '../../utils/express.js'
 
 const nodeRouter = Router()
 
-nodeRouter.get('/:cid', async (req, res) => {
-  const cid = req.params.cid
-  const node = await dsnFetcher.fetchNode(cid, true)
+nodeRouter.get(
+  '/:cid',
+  asyncSafeHandler(async (req, res) => {
+    const cid = req.params.cid
+    const node = await dsnFetcher.fetchNode(cid, true)
 
-  const ipldNode = safeIPLDDecode(node)
+    const ipldNode = safeIPLDDecode(node)
 
-  res.json({
-    links: node.Links.map((l) => cidToString(l.Hash)),
-    data: Buffer.from(ipldNode!.data ?? '').toString('base64'),
-    size: (ipldNode?.size ?? BigInt(0)).toString(),
-    filename: ipldNode?.name,
-  })
-})
+    res.json({
+      links: node.Links.map((l) => cidToString(l.Hash)),
+      data: Buffer.from(ipldNode!.data ?? '').toString('base64'),
+      size: (ipldNode?.size ?? BigInt(0)).toString(),
+      filename: ipldNode?.name,
+    })
+  }),
+)
 
 export { nodeRouter }

--- a/services/file-retriever/src/http/middlewares/auth.ts
+++ b/services/file-retriever/src/http/middlewares/auth.ts
@@ -1,7 +1,8 @@
 import { Handler, NextFunction, Request, Response } from 'express'
 import { config } from '../../config.js'
+import { asyncSafeHandler } from '../../utils/express.js'
 
-export const authMiddleware: Handler = (
+export const authMiddleware: Handler = asyncSafeHandler((
   req: Request,
   res: Response,
   next: NextFunction,
@@ -26,4 +27,4 @@ export const authMiddleware: Handler = (
   }
 
   next()
-}
+})

--- a/services/file-retriever/src/utils/express.ts
+++ b/services/file-retriever/src/utils/express.ts
@@ -1,0 +1,13 @@
+import { NextFunction, Request, Response } from 'express'
+
+export const asyncSafeHandler = (
+  fn: (req: Request, res: Response, next: NextFunction) => unknown,
+) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      await fn(req, res, next)
+    } catch (err) {
+      next(err)
+    }
+  }
+}

--- a/services/object-mapping-indexer/package.json
+++ b/services/object-mapping-indexer/package.json
@@ -20,6 +20,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
+    "express-async-errors": "^3.1.1",
     "pg": "^8.13.1",
     "pg-format": "^1.0.4",
     "uuid": "^11.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,6 +3117,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-async-errors@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "express-async-errors@npm:3.1.1"
+  peerDependencies:
+    express: ^4.16.2
+  checksum: 10c0/56c4e90c44e98c7edc5bd38e18dd23b0d9a7139cb94ff3e25943ba257415b433e0e52ea8f9bc1fb5b70a5e6c5246eaace4fb69ab171edfb8896580928bb97ec6
+  languageName: node
+  linkType: hard
+
 "express@npm:^4.21.1":
   version: 4.21.1
   resolution: "express@npm:4.21.1"
@@ -3277,6 +3286,7 @@ __metadata:
     cpu-features: "npm:^0.0.10"
     dotenv: "npm:^16.4.7"
     express: "npm:^4.21.1"
+    express-async-errors: "npm:^3.1.1"
     keyv: "npm:^5.2.1"
     lru-cache: "npm:^11.0.2"
     mime-types: "npm:^2.1.35"
@@ -4685,6 +4695,7 @@ __metadata:
     eslint-plugin-eslint-plugin: "npm:^6.3.1"
     eslint-plugin-prettier: "npm:^5.2.1"
     express: "npm:^4.21.1"
+    express-async-errors: "npm:^3.1.1"
     pg: "npm:^8.13.1"
     pg-format: "npm:^1.0.4"
     prettier: "npm:^3.3.3"


### PR DESCRIPTION
The error handler in express doesn't work for errors thrown in async context. For solving this, async request handlers should be wrapped with a try/catch and calling next when an error is catched.