### PR TITLE
Fix inconsistent cache state

### DIFF
--- a/services/file-retriever/src/services/fileCache/index.ts
+++ b/services/file-retriever/src/services/fileCache/index.ts
@@ -69,22 +69,16 @@ export const createFileCache = (config: BaseCacheConfig) => {
     const { data, ...rest } = fileResponse
 
     const start = performance.now()
-    const cachePromise = filepathCache
-      .set(cid, {
-        ...rest,
-      })
-      .then(() => {
-        const end = performance.now()
-        logger.debug(`Caching file for ${cid} took ${end - start}ms`)
-      })
+    await writeFile(filePath, data)
+    const end = performance.now()
+    logger.debug(`Writing file to cache for ${cid} took ${end - start}ms`)
 
     const start2 = performance.now()
-    const writePromise = writeFile(filePath, data).then(() => {
-      const end2 = performance.now()
-      logger.debug(`Writing file to cache for ${cid} took ${end2 - start2}ms`)
+    await filepathCache.set(cid, {
+      ...rest,
     })
-
-    await Promise.all([cachePromise, writePromise])
+    const end2 = performance.now()
+    logger.debug(`Caching file for ${cid} took ${end2 - start2}ms`)
   }
 
   const remove = async (cid: string) => {


### PR DESCRIPTION
When a big file was retrieved the cache had an inconsistent state where the `filePathCache` would state that the file was cached though the file wasn't yet fully downloaded. 

This was a problem when you re-fetch a downloading file since the cache would state that the file should be cached when it wasn't leading to a file system error (no existing file).

Making the `filePathCache` update only after the file is fully written solves this issue.