### PR TITLE
Refactor DSN fetcher

### DIFF
--- a/services/file-retriever/src/services/fileCache/index.ts
+++ b/services/file-retriever/src/services/fileCache/index.ts
@@ -69,22 +69,16 @@ export const createFileCache = (config: BaseCacheConfig) => {
     const { data, ...rest } = fileResponse
 
     const start = performance.now()
-    const cachePromise = filepathCache
-      .set(cid, {
-        ...rest,
-      })
-      .then(() => {
-        const end = performance.now()
-        logger.debug(`Caching file for ${cid} took ${end - start}ms`)
-      })
+    await writeFile(filePath, data)
+    const end = performance.now()
+    logger.debug(`Writing file to cache for ${cid} took ${end - start}ms`)
 
     const start2 = performance.now()
-    const writePromise = writeFile(filePath, data).then(() => {
-      const end2 = performance.now()
-      logger.debug(`Writing file to cache for ${cid} took ${end2 - start2}ms`)
+    await filepathCache.set(cid, {
+      ...rest,
     })
-
-    await Promise.all([cachePromise, writePromise])
+    const end2 = performance.now()
+    logger.debug(`Caching file for ${cid} took ${end2 - start2}ms`)
   }
 
   const remove = async (cid: string) => {


### PR DESCRIPTION
This PR makes two updates:

* Removing concurrent fetches limit at request level: At #8 the `config.maxConcurrentFetches` we changed this limit from the request level to the app level, instead of making only N concurrent fetches per request if two files are requested simultaneously only N applies globally. 

* Add error handling to stream in case some node fetch failed. Note that the `subspace-gateway` already implements retries so we didn't at this level.