### PR TITLE
update: improve caching setup

### DIFF
--- a/benchmarks/taurus.js
+++ b/benchmarks/taurus.js
@@ -6,7 +6,7 @@ export default async function () {
   group('Concurrent Requests', function () {
     return http.batch(
       taurusFiles.map((file) => ({
-        url: `http://localhost:8090/files/${file}?api_key=random-secret`,
+        url: `https://gateway.taurus.autonomys.xyz/files/${file}?api_key=28592507e0de9a9bde5b45dbe3ecb7fd`,
         params: {
           timeout: '1h',
         },

--- a/benchmarks/taurus.js
+++ b/benchmarks/taurus.js
@@ -6,7 +6,7 @@ export default async function () {
   group('Concurrent Requests', function () {
     return http.batch(
       taurusFiles.map((file) => ({
-        url: `https://gateway.taurus.autonomys.xyz/files/${file}?api_key=28592507e0de9a9bde5b45dbe3ecb7fd`,
+        url: `http://localhost:8090/files/${file}?api_key=random-secret`,
         params: {
           timeout: '1h',
         },

--- a/docker/file-retriever/docker-compose.yml
+++ b/docker/file-retriever/docker-compose.yml
@@ -3,7 +3,7 @@ volumes:
 
 services:
   subspace-node:
-    image: ghcr.io/autonomys/node:${NODE_DOCKER_TAG}
+    image: ${NODE_DOCKER_TAG}
     volumes:
       - subspace-node-data:/var/subspace:rw
     ports:
@@ -30,7 +30,7 @@ services:
       retries: 60
     stop_grace_period: 30s
   subspace-http-gateway:
-    image: ghcr.io/autonomys/gateway:${GATEWAY_DOCKER_TAG}
+    image: ${GATEWAY_DOCKER_TAG}
     depends_on:
       subspace-node:
         condition: service_healthy
@@ -74,9 +74,9 @@ services:
     pid: host
     privileged: true
     volumes:
-      - "/:/host:ro"
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      - '/:/host:ro'
+      - '/var/run/docker.sock:/var/run/docker.sock'
     environment:
-      NRIA_LICENSE_KEY: "${NR_API_KEY}"
-      NRIA_DISPLAY_NAME: "${NR_AGENT_IDENTIFIER}"
+      NRIA_LICENSE_KEY: '${NR_API_KEY}'
+      NRIA_DISPLAY_NAME: '${NR_AGENT_IDENTIFIER}'
     restart: unless-stopped

--- a/docker/file-retriever/docker-compose.yml
+++ b/docker/file-retriever/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       dockerfile: docker/file-retriever/Dockerfile
     container_name: file-retriever
     volumes:
-      - file-retriever-data:/.cache
+      - file-retriever-data:/app
     ports:
       - '8090:8090'
     environment:

--- a/docker/file-retriever/docker-compose.yml
+++ b/docker/file-retriever/docker-compose.yml
@@ -1,5 +1,6 @@
 volumes:
   subspace-node-data: {}
+  file-retriever-data: {}
 
 services:
   subspace-node:
@@ -47,7 +48,7 @@ services:
       dockerfile: docker/file-retriever/Dockerfile
     container_name: file-retriever
     volumes:
-      - .cache:/.cache
+      - file-retriever-data:/.cache
     ports:
       - '8090:8090'
     environment:

--- a/docker/object-mapping-indexer/docker-compose.yml
+++ b/docker/object-mapping-indexer/docker-compose.yml
@@ -3,7 +3,7 @@ volumes:
 
 services:
   subspace-node:
-    image: ghcr.io/autonomys/node:${NODE_DOCKER_TAG}
+    image: ${NODE_DOCKER_TAG}
     volumes:
       - subspace-node-data:/var/subspace:rw
     ports:

--- a/services/file-retriever/src/services/fileCache/index.ts
+++ b/services/file-retriever/src/services/fileCache/index.ts
@@ -30,7 +30,6 @@ export const createFileCache = (config: BaseCacheConfig) => {
 
   const filepathCache = createCache({
     stores: config.stores,
-    nonBlocking: true,
   })
 
   const deserialize = (data: Omit<FileResponse, 'data'> | null) => {

--- a/services/file-retriever/src/services/fileComposer.ts
+++ b/services/file-retriever/src/services/fileComposer.ts
@@ -53,7 +53,7 @@ const get = async (cid: string): Promise<FileResponse> => {
   end = performance.now()
   logger.debug(`Forking file ${cid} took ${end - start}ms`)
 
-  await cache
+  cache
     .set(cid, {
       ...file,
       data: cachingStream,

--- a/services/object-mapping-indexer/node-docker-compose.yml
+++ b/services/object-mapping-indexer/node-docker-compose.yml
@@ -3,7 +3,7 @@ volumes:
 
 services:
   node:
-    image: ghcr.io/autonomys/node:${NODE_DOCKER_TAG}
+    image: ${NODE_DOCKER_TAG}
     volumes:
       - node-data:/var/subspace:rw
     ports:

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,5 @@
+import { taurusFiles } from './benchmarks/files/taurus.js'
+
+taurusFiles.map((file) => {
+  fetch(`http://localhost:8090/files/${file}?api_key=random-secret`)
+})


### PR DESCRIPTION
This PR improves the caching setup in these aspects:

- Blocking cache set: This ensures that all layers of the cache (memory & sqlite) are updated on a Set event.
- Not waiting to cache be updated for streamline the file back to the user
- Add a volume that persists within updates in container

Lastly, I removed the prefix of the ${NODE_DOCKER_TAG} & ${GATEWAY_DOCKER_TAG} and the user should put the prefix if wanted. 