### PR TITLE
Handle reconnections in indexer

### DIFF
--- a/docker/file-retriever/docker-compose.yml
+++ b/docker/file-retriever/docker-compose.yml
@@ -3,33 +3,6 @@ volumes:
   file-retriever-data: {}
 
 services:
-  subspace-node:
-    image: ${NODE_DOCKER_TAG}
-    volumes:
-      - subspace-node-data:/var/subspace:rw
-    ports:
-      - '30333:30333'
-      - '30433:30433'
-      - '127.0.0.1:9944:9944'
-    restart: unless-stopped
-    command: >
-      run
-      --chain ${NETWORK_ID}
-      --base-path /var/subspace
-      --listen-on /ip4/0.0.0.0/tcp/30333
-      --dsn-listen-on /ip4/0.0.0.0/tcp/30433
-      --rpc-cors all
-      --rpc-methods unsafe
-      --rpc-listen-on 0.0.0.0:9944
-      --rpc-max-subscriptions-per-connection 1000
-      --rpc-max-connections 20000
-      --name object-mapping-node
-      --sync full
-    healthcheck:
-      timeout: 5s
-      interval: 30s
-      retries: 60
-    stop_grace_period: 30s
   subspace-http-gateway:
     image: ${GATEWAY_DOCKER_TAG}
     depends_on:

--- a/services/object-mapping-indexer/src/drivers/substrateEvents.ts
+++ b/services/object-mapping-indexer/src/drivers/substrateEvents.ts
@@ -13,10 +13,17 @@ type SubstrateEventListenerState = {
   ws: WS
 }
 
-export const createSubstrateEventListener = () => {
+export const createSubstrateEventListener = ({
+  onReconnection,
+}: {
+  onReconnection?: () => void
+}) => {
   const state: SubstrateEventListenerState = {
     subscriptions: {},
-    ws: createWS(config.nodeRpcUrl),
+    ws: createWS({
+      endpoint: config.nodeRpcUrl,
+      onReconnection,
+    }),
   }
 
   const subscribe = async (
@@ -92,5 +99,9 @@ export const createSubstrateEventListener = () => {
     subscription.callbacks.forEach((callback) => callback(data.params.result))
   })
 
-  return { subscribe }
+  const wipe = () => {
+    state.subscriptions = {}
+  }
+
+  return { subscribe, wipe }
 }

--- a/services/object-mapping-indexer/src/utils/promise.ts
+++ b/services/object-mapping-indexer/src/utils/promise.ts
@@ -1,0 +1,1 @@
+export const unresolvablePromise = new Promise<void>(() => {})

--- a/services/object-mapping-indexer/src/utils/timeout.ts
+++ b/services/object-mapping-indexer/src/utils/timeout.ts
@@ -1,0 +1,1 @@
+export const schedule = setTimeout


### PR DESCRIPTION
Reconnections were not handled so if the node closed the connection or an error occurred no more object mappings would be introduced. 