### PR TITLE
fix: node object mapping listener rpc client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-build:
-	yarn build
+all: common models rpc indexer file-retriever
 
 models:
 	yarn models build

--- a/services/object-mapping-indexer/src/services/objectMappingListener/index.ts
+++ b/services/object-mapping-indexer/src/services/objectMappingListener/index.ts
@@ -23,8 +23,10 @@ export const createObjectMappingListener = (): ObjectMappingListener => {
       const client = SubspaceObjectListenerAPI.createClient({
         endpoint: config.nodeRpcUrl,
         callbacks: {
-          onOpen: init,
-          onReconnection: init,
+          onEveryOpen: init,
+          onReconnection: () => {
+            logger.warn('Reconnecting to object mapping indexer')
+          },
         },
       })
     },


### PR DESCRIPTION
Fixed the object mapping listener RPC client setup after the [callbacks naming update](https://github.com/autonomys/auto-sdk/pull/353)