### PR TITLE
fix: blocking batches

### DIFF
--- a/services/file-retriever/src/services/batchOptimizer.ts
+++ b/services/file-retriever/src/services/batchOptimizer.ts
@@ -1,6 +1,11 @@
 import { config } from '../config.js'
 import { ObjectMapping } from './objectMappingIndexer.js'
 
+const maxObjectsPerBatch = Math.min(
+  config.maxObjectsPerFetch,
+  config.maxSimultaneousFetches,
+)
+
 export const optimizeBatchFetch = (
   objects: ObjectMapping[],
 ): ObjectMapping[][] => {
@@ -21,7 +26,7 @@ export const optimizeBatchFetch = (
       pieceIndex === safePieceIndex ||
       pieceIndex === safePieceIndex + 1 ||
       lastPieceIndex === null
-    const isFull = currentBatch.length === config.maxObjectsPerFetch
+    const isFull = currentBatch.length === maxObjectsPerBatch
 
     // if pieces are not consecutive, they're not sharing the same piece
     if (isSameOrConsecutive && !isFull) {
@@ -43,7 +48,7 @@ export const optimizeBatchFetch = (
   return optimizedObjects.reduce(
     (acc, curr) => {
       const lastBatch = acc[acc.length - 1]
-      if (lastBatch.length + curr.length <= config.maxObjectsPerFetch) {
+      if (lastBatch.length + curr.length <= maxObjectsPerBatch) {
         acc[acc.length - 1] = lastBatch.concat(curr)
       } else {
         acc.push(curr)

--- a/services/file-retriever/src/utils/retries.ts
+++ b/services/file-retriever/src/utils/retries.ts
@@ -1,0 +1,26 @@
+type RetryOptions = {
+  maxRetries?: number
+  delay?: number
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export const withRetries = async <T>(
+  fn: () => Promise<T>,
+  { maxRetries = 5, delay = 1000 }: RetryOptions = {},
+): Promise<T> => {
+  let retries = 0
+  let lastError: Error
+
+  while (retries < maxRetries) {
+    try {
+      return await fn()
+    } catch (error) {
+      lastError = error as Error
+      retries++
+      await sleep(delay)
+    }
+  }
+
+  throw lastError!
+}


### PR DESCRIPTION
Subspace gateway has a maximum of objects that can be handled by every RPC request, this is represented by `maxObjectsPerFetch` but also we want to limit the simultaneous number of requests that are pending to be retrieved. 

So, maybe we want to simultaneously run two 50-sized objects fetch. For that we'd configure `50` and `100` for `maxObjectsPerFetch` and `maxSimultaneousFetches` respectively. 

The issue here is that  `maxObjectsPerFetch` was setup a higher value than `maxSimultaneousFetches` effectively blocking execution of this job. [For avoiding this issue in the future I'm updating `weightedRequestConcurrencyController` to throw an error when a job has a weight higher than the maximum concurrency.](https://github.com/autonomys/auto-sdk/pull/390) 