### PR TITLE
chore: fix linting for detecting imports w/o extension

### DIFF
--- a/common/models/eslint.config.mjs
+++ b/common/models/eslint.config.mjs
@@ -5,7 +5,6 @@ import tsParser from '@typescript-eslint/parser'
 import prettier from 'eslint-plugin-prettier'
 import { defineConfig, globalIgnores } from 'eslint/config'
 import globals from 'globals'
-import requireExtensions from 'eslint-plugin-require-extensions'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -36,13 +35,12 @@ export default defineConfig([
     extends: compat.extends(
       'eslint:recommended',
       'plugin:@typescript-eslint/recommended',
-      'plugin:require-extensions/error',
+      'plugin:require-extensions/recommended',
       'prettier',
     ),
 
     plugins: {
       '@typescript-eslint': typescriptEslint,
-      'require-extensions': requireExtensions,
       prettier,
     },
 
@@ -69,6 +67,7 @@ export default defineConfig([
       'spaced-comment': 'error',
       quotes: ['error', 'single'],
       'no-duplicate-imports': 'error',
+      'require-extensions/require-extensions': 'error',
     },
   },
 ])

--- a/common/models/package.json
+++ b/common/models/package.json
@@ -17,7 +17,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "typescript": "^5.6.3"

--- a/common/rpc-apis/eslint.config.mjs
+++ b/common/rpc-apis/eslint.config.mjs
@@ -5,7 +5,6 @@ import tsParser from '@typescript-eslint/parser'
 import prettier from 'eslint-plugin-prettier'
 import { defineConfig, globalIgnores } from 'eslint/config'
 import globals from 'globals'
-import requireExtensions from 'eslint-plugin-require-extensions'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -36,13 +35,12 @@ export default defineConfig([
     extends: compat.extends(
       'eslint:recommended',
       'plugin:@typescript-eslint/recommended',
-      'plugin:require-extensions/error',
+      'plugin:require-extensions/recommended',
       'prettier',
     ),
 
     plugins: {
       '@typescript-eslint': typescriptEslint,
-      'require-extensions': requireExtensions,
       prettier,
     },
 
@@ -69,6 +67,7 @@ export default defineConfig([
       'spaced-comment': 'error',
       quotes: ['error', 'single'],
       'no-duplicate-imports': 'error',
+      'require-extensions/require-extensions': 'error',
     },
   },
 ])

--- a/common/rpc-apis/package.json
+++ b/common/rpc-apis/package.json
@@ -18,7 +18,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "typescript": "^5.6.3"

--- a/common/rpc-apis/src/objectMappingIndexer.ts
+++ b/common/rpc-apis/src/objectMappingIndexer.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { defineUnvalidatedType, createApiDefinition } from '@autonomys/rpc'
 import { z } from 'zod'
 import { ObjectMapping } from '@auto-files/models'

--- a/common/rpc-apis/src/subspaceObjectListener.ts
+++ b/common/rpc-apis/src/subspaceObjectListener.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { ObjectMappingListEntry } from '@auto-files/models'
 import { createApiDefinition, defineUnvalidatedType } from '@autonomys/rpc'
 

--- a/services/file-retriever/__tests__/batchOptimizer.spec.ts
+++ b/services/file-retriever/__tests__/batchOptimizer.spec.ts
@@ -1,6 +1,6 @@
-import { config } from '../src/config'
-import { optimizeBatchFetch } from '../src/services/batchOptimizer'
-import { ObjectMapping } from '../src/services/objectMappingIndexer'
+import { config } from '../src/config.js'
+import { optimizeBatchFetch } from '../src/services/batchOptimizer.js'
+import { ObjectMapping } from '@auto-files/models'
 
 describe('Batch Optimizer', () => {
   it('should optimize the batch and merge the batches', () => {

--- a/services/file-retriever/eslint.config.mjs
+++ b/services/file-retriever/eslint.config.mjs
@@ -5,7 +5,6 @@ import tsParser from '@typescript-eslint/parser'
 import prettier from 'eslint-plugin-prettier'
 import { defineConfig, globalIgnores } from 'eslint/config'
 import globals from 'globals'
-import requireExtensions from 'eslint-plugin-require-extensions'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -36,13 +35,12 @@ export default defineConfig([
     extends: compat.extends(
       'eslint:recommended',
       'plugin:@typescript-eslint/recommended',
-      'plugin:require-extensions/error',
+      'plugin:require-extensions/recommended',
       'prettier',
     ),
 
     plugins: {
       '@typescript-eslint': typescriptEslint,
-      'require-extensions': requireExtensions,
       prettier,
     },
 
@@ -69,6 +67,7 @@ export default defineConfig([
       'spaced-comment': 'error',
       quotes: ['error', 'single'],
       'no-duplicate-imports': 'error',
+      'require-extensions/require-extensions': 'error',
     },
   },
 ])

--- a/services/file-retriever/package.json
+++ b/services/file-retriever/package.json
@@ -36,7 +36,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "devrun": "node --loader ts-node/esm",
-    "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --runInBand --coverage"
+    "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --runInBand --coverage",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "@types/cpu-features": "^0",

--- a/services/file-retriever/src/services/objectMappingIndexer.ts
+++ b/services/file-retriever/src/services/objectMappingIndexer.ts
@@ -1,5 +1,5 @@
 import { ObjectMappingIndexerRPCApi } from '@auto-files/rpc-apis'
-import { config } from '../config'
+import { config } from '../config.js'
 
 export const objectMappingIndexer = ObjectMappingIndexerRPCApi.createHttpClient(
   config.objectMappingIndexerUrl,

--- a/services/object-mapping-indexer/eslint.config.mjs
+++ b/services/object-mapping-indexer/eslint.config.mjs
@@ -5,7 +5,6 @@ import tsParser from '@typescript-eslint/parser'
 import prettier from 'eslint-plugin-prettier'
 import { defineConfig, globalIgnores } from 'eslint/config'
 import globals from 'globals'
-import requireExtensions from 'eslint-plugin-require-extensions'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -36,13 +35,12 @@ export default defineConfig([
     extends: compat.extends(
       'eslint:recommended',
       'plugin:@typescript-eslint/recommended',
-      'plugin:require-extensions/error',
+      'plugin:require-extensions/recommended',
       'prettier',
     ),
 
     plugins: {
       '@typescript-eslint': typescriptEslint,
-      'require-extensions': requireExtensions,
       prettier,
     },
 
@@ -69,6 +67,7 @@ export default defineConfig([
       'spaced-comment': 'error',
       quotes: ['error', 'single'],
       'no-duplicate-imports': 'error',
+      'require-extensions/require-extensions': 'error',
     },
   },
 ])

--- a/services/object-mapping-indexer/package.json
+++ b/services/object-mapping-indexer/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "node --loader ts-node/esm"
+    "dev": "node --loader ts-node/esm",
+    "lint": "eslint ."
   },
   "license": "MIT",
   "dependencies": {

--- a/services/object-mapping-indexer/src/rpc/server.ts
+++ b/services/object-mapping-indexer/src/rpc/server.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { objectMappingRouter } from '../services/objectMappingRouter/index.js'
 import { ObjectMappingIndexerRPCApi } from '@auto-files/rpc-apis'
 import { expressApp } from '../http/api.js'


### PR DESCRIPTION
In the last update there was an invalid import 'path/to/file' w/o `.js` extension. This PR fixes this and the eslint configuration for detecting this error in build time. 