### PR TITLE
fix: ensure order in batched request

### DIFF
--- a/services/file-retriever/src/services/dsnFetcher.ts
+++ b/services/file-retriever/src/services/dsnFetcher.ts
@@ -170,14 +170,11 @@ const fetchFileAsStream = (node: PBNode): Readable => {
         )
         while (requestsPending.length > 0) {
           // we fetch the object mappings in parallel
-          const objectMappings = await objectMappingIndexer
-            .get_object_mappings({
+          const objectMappings = await objectMappingIndexer.get_object_mappings(
+            {
               hashes: requestsPending,
-            })
-            .then((objectMappings) =>
-              objectMappings.map((e) => [e[0], e[1], e[2]]),
-            )
-
+            },
+          )
           // we group the object mapping by the piece index
           const nodes = optimizeBatchFetch(objectMappings)
 

--- a/services/file-retriever/src/services/dsnFetcher.ts
+++ b/services/file-retriever/src/services/dsnFetcher.ts
@@ -170,11 +170,14 @@ const fetchFileAsStream = (node: PBNode): Readable => {
         )
         while (requestsPending.length > 0) {
           // we fetch the object mappings in parallel
-          const objectMappings = await objectMappingIndexer.get_object_mappings(
-            {
+          const objectMappings = await objectMappingIndexer
+            .get_object_mappings({
               hashes: requestsPending,
-            },
-          )
+            })
+            .then((objectMappings) =>
+              objectMappings.map((e) => [e[0], e[1], e[2]]),
+            )
+
           // we group the object mapping by the piece index
           const nodes = optimizeBatchFetch(objectMappings)
 

--- a/services/object-mapping-indexer/src/useCases/objectMapping.ts
+++ b/services/object-mapping-indexer/src/useCases/objectMapping.ts
@@ -76,7 +76,20 @@ const getObjectMappings = async (
 ): Promise<ObjectMapping[]> => {
   const objectMappings = await objectMappingRepository.getByHashes(hashes)
 
-  return objectMappings.map((e) => [e.hash, e.pieceIndex, e.pieceOffset])
+  // Create a map of hash to object mapping for quick lookup
+  const mappingsByHash = new Map<string, ObjectMapping>(
+    objectMappings.map((e) => [e.hash, [e.hash, e.pieceIndex, e.pieceOffset]]),
+  )
+
+  // Return results in the same order as input hashes
+  return hashes.map((hash) => {
+    const mapping = mappingsByHash.get(hash)
+    if (!mapping) {
+      throw new Error('Object mapping not found')
+    }
+
+    return mapping
+  })
 }
 
 export const objectMappingUseCase = {


### PR DESCRIPTION
Return a list with the same sequence of hashes present in the request