### PR TITLE
chore: make RUST_LOG environment variables been setup by .env 

### DIFF
--- a/docker/file-retriever/docker-compose.yml
+++ b/docker/file-retriever/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     stop_grace_period: 30s
     command: rpc --node-rpc-url ws://subspace-node:9944/ws --rpc-listen-on 0.0.0.0:9955 --allow-private-ips --out-connections ${OUT_CONNECTIONS} --pending-out-connections ${PENDING_OUT_CONNECTIONS}
     environment:
-      - RUST_LOG=debug
+      - RUST_LOG=${RUST_LOG_GATEWAY:-info}
   file-retriever:
     image: ${FILE_RETRIEVER_DOCKER_TAG}
     container_name: file-retriever

--- a/docker/object-mapping-indexer/docker-compose.yml
+++ b/docker/object-mapping-indexer/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - '30433:30433'
       - '127.0.0.1:9944:9944'
     restart: unless-stopped
+    environment:
+      - RUST_LOG=${RUST_LOG_NODE:-info}
     command: >
       run
       --chain ${NETWORK_ID}


### PR DESCRIPTION
They were hardcoded to "debug", what was inconvenient for production setups