### PR TITLE
feat: add partial downloads

### DIFF
--- a/services/file-retriever/__tests__/partialDownloads.spec.ts
+++ b/services/file-retriever/__tests__/partialDownloads.spec.ts
@@ -51,7 +51,8 @@ describe('Partial downloads', () => {
 
     // First node (head) should return null
     const chunk = await dsnFetcher.getPartial(cid, 0)
-    expect(chunk).toBeNull()
+    expect(chunk).toBeInstanceOf(Buffer)
+    expect(chunk?.length).toBe(0)
 
     // Chunks 1-5 should return the correct chunk
     let i = 0
@@ -65,8 +66,7 @@ describe('Partial downloads', () => {
 
     // Chunk 6 should return empty buffer because it's past the end of the file
     const chunk6 = await dsnFetcher.getPartial(cid, 6)
-    expect(chunk6).toBeDefined()
-    expect(chunk6?.length).toBe(0)
+    expect(chunk6).toBeNull()
   })
 
   it('should work with a large file', async () => {
@@ -103,14 +103,13 @@ describe('Partial downloads', () => {
     while (received < chunks.length) {
       const chunk = await dsnFetcher.getPartial(cid, index)
       index++
-      if (chunk) {
+      if (chunk && chunk?.length > 0) {
         expect(chunk.toString('hex')).toBe(chunks[received].toString('hex'))
         received++
       }
     }
 
     const finalResult = await dsnFetcher.getPartial(cid, index)
-    expect(finalResult).toBeInstanceOf(Buffer)
-    expect(finalResult?.length).toBe(0)
+    expect(finalResult).toBeNull()
   })
 })

--- a/services/file-retriever/__tests__/partialDownloads.spec.ts
+++ b/services/file-retriever/__tests__/partialDownloads.spec.ts
@@ -1,0 +1,116 @@
+import {
+  createFileChunkIpldNode,
+  PBNode,
+  cidToString,
+  cidOfNode,
+  createChunkedFileIpldNode,
+  processFileToIPLDFormat,
+  stringToCid,
+  decodeNode,
+  NODE_METADATA_SIZE,
+} from '@autonomys/auto-dag-data'
+import { dsnFetcher } from '../src/services/dsnFetcher.js'
+import { jest } from '@jest/globals'
+import { randomBytes } from 'crypto'
+import { MemoryBlockstore } from 'blockstore-core'
+
+describe('Partial downloads', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return the correct chunk', async () => {
+    const nodeMapByCID: Record<string, PBNode> = {}
+    const chunks = ['a', 'b', 'c', 'd', 'e']
+
+    // Create the tree of nodes
+    const nodes = chunks.map((chunk) =>
+      createFileChunkIpldNode(Buffer.from(chunk, 'utf-8')),
+    )
+    const headNode = createChunkedFileIpldNode(
+      nodes.map((node) => cidOfNode(node)),
+      5n,
+      1,
+    )
+
+    // Create a map of the nodes by CID
+    nodes.forEach((node) => {
+      const cid = cidToString(cidOfNode(node))
+      nodeMapByCID[cid] = node
+    })
+    nodeMapByCID[cidToString(cidOfNode(headNode))] = headNode
+
+    const cid = cidToString(cidOfNode(headNode))
+
+    jest.spyOn(dsnFetcher, 'fetchNode').mockImplementation(async (cid) => {
+      return nodeMapByCID[cid]
+    })
+
+    // First node (head) should return null
+    const chunk = await dsnFetcher.getPartial(cid, 0)
+    expect(chunk).toBeNull()
+
+    // Chunks 1-5 should return the correct chunk
+    let i = 0
+    while (i < chunks.length) {
+      // i + 1 for offsetting the head node
+      const chunk = await dsnFetcher.getPartial(cid, i + 1)
+      expect(chunk).toBeDefined()
+      expect(chunk?.toString('utf-8')).toBe(chunks[i])
+      i++
+    }
+
+    // Chunk 6 should return empty buffer because it's past the end of the file
+    const chunk6 = await dsnFetcher.getPartial(cid, 6)
+    expect(chunk6).toBeDefined()
+    expect(chunk6?.length).toBe(0)
+  })
+
+  it('should work with a large file', async () => {
+    const chunksCount = 30
+    const maxLinkPerNode = 5
+    const chunkSize = 50
+    const totalSize = chunksCount * chunkSize
+
+    const chunks = Array.from({ length: chunksCount }).map(() =>
+      randomBytes(chunkSize),
+    )
+
+    const blockstore = new MemoryBlockstore()
+
+    const cid = cidToString(
+      await processFileToIPLDFormat(
+        blockstore,
+        chunks,
+        BigInt(totalSize),
+        'dag-cbor',
+        {
+          maxLinkPerNode,
+          maxNodeSize: chunkSize + NODE_METADATA_SIZE,
+        },
+      ),
+    )
+
+    jest.spyOn(dsnFetcher, 'fetchNode').mockImplementation(async (cid) => {
+      return decodeNode(await blockstore.get(stringToCid(cid)))
+    })
+
+    let index = 0,
+      received = 0
+    while (received < chunks.length) {
+      const chunk = await dsnFetcher.getPartial(cid, index)
+      index++
+      if (chunk) {
+        expect(chunk.toString('hex')).toBe(chunks[received].toString('hex'))
+        received++
+      }
+    }
+
+    const finalResult = await dsnFetcher.getPartial(cid, index)
+    expect(finalResult).toBeInstanceOf(Buffer)
+    expect(finalResult?.length).toBe(0)
+  })
+})

--- a/services/file-retriever/package.json
+++ b/services/file-retriever/package.json
@@ -4,10 +4,10 @@
   "type": "module",
   "dependencies": {
     "@auto-files/rpc-apis": "workspace:*",
-    "@autonomys/asynchronous": "^1.4.31",
+    "@autonomys/asynchronous": "^1.4.36",
     "@autonomys/auto-dag-data": "^1.4.31",
     "@autonomys/auto-utils": "^1.4.31",
-    "@autonomys/file-caching": "^1.4.31",
+    "@autonomys/file-caching": "^1.4.36",
     "@autonomys/rpc": "^1.4.31",
     "@ipld/dag-pb": "^4.1.3",
     "@keyvhq/core": "^2.1.1",

--- a/services/file-retriever/src/http/controllers/file.ts
+++ b/services/file-retriever/src/http/controllers/file.ts
@@ -7,6 +7,7 @@ import { asyncSafeHandler } from '../../utils/express.js'
 import { uniqueHeaderValue } from '../../utils/http.js'
 import { HttpError } from '../middlewares/error.js'
 import { dsnFetcher } from '../../services/dsnFetcher.js'
+import { safeIPLDDecode } from '../../utils/dagData.js'
 
 const fileRouter = Router()
 
@@ -63,8 +64,37 @@ fileRouter.get(
   }),
 )
 
+fileRouter.head(
+  '/:cid',
+  authMiddleware,
+  asyncSafeHandler(async (req, res) => {
+    const cid = req.params.cid
+
+    const file = await dsnFetcher.fetchNode(cid, [])
+    if (file) {
+      const metadata = safeIPLDDecode(file)
+      const size = metadata?.size
+      const isCompressed = metadata?.uploadOptions?.compression
+      const isEncrypted = metadata?.uploadOptions?.encryption
+      if (size) {
+        res.set('Content-Length', size.toString())
+        res.set('Content-Type', 'application/octet-stream')
+      }
+      if (isCompressed && !isEncrypted) {
+        res.set('Content-Encoding', 'deflate')
+      } else if (isEncrypted) {
+        res.set('Content-Encoding', 'aes-256-gcm')
+      }
+      res.sendStatus(204)
+    } else {
+      res.sendStatus(404)
+    }
+  }),
+)
+
 fileRouter.get(
   '/:cid/partial',
+  authMiddleware,
   asyncSafeHandler(async (req, res) => {
     const cid = req.params.cid
     const chunk = parseInt(req.query.chunk as string)

--- a/services/file-retriever/src/http/controllers/node.ts
+++ b/services/file-retriever/src/http/controllers/node.ts
@@ -9,7 +9,7 @@ nodeRouter.get(
   '/:cid',
   asyncSafeHandler(async (req, res) => {
     const cid = req.params.cid
-    const node = await dsnFetcher.fetchNode(cid)
+    const node = await dsnFetcher.fetchNode(cid, [])
 
     res.json(node)
   }),
@@ -19,7 +19,7 @@ nodeRouter.get(
   '/:cid/ipld',
   asyncSafeHandler(async (req, res) => {
     const cid = req.params.cid
-    const node = await dsnFetcher.fetchNode(cid)
+    const node = await dsnFetcher.fetchNode(cid, [])
 
     const ipldNode = safeIPLDDecode(node)
 

--- a/services/file-retriever/src/services/cache.ts
+++ b/services/file-retriever/src/services/cache.ts
@@ -1,0 +1,15 @@
+import {
+  createFileCache,
+  defaultMemoryAndSqliteConfig,
+  ensureDirectoryExists,
+} from '@autonomys/file-caching'
+import path from 'path'
+import { config } from '../config.js'
+
+export const cache = createFileCache(
+  defaultMemoryAndSqliteConfig({
+    dirname: ensureDirectoryExists(path.join(config.cacheDir, 'files')),
+    cacheMaxSize: config.cacheMaxSize,
+    cacheTtl: config.cacheTtl,
+  }),
+)

--- a/services/file-retriever/src/services/dsnFetcher.ts
+++ b/services/file-retriever/src/services/dsnFetcher.ts
@@ -333,15 +333,13 @@ const getPartial = async (
   // if the node is not found, the chunk is not present
   // and therefore the file has finished being downloaded
   if (!node) {
-    return Buffer.from([])
+    return null
   }
   const ipldMetadata = safeIPLDDecode(node)
   if (!ipldMetadata) {
     throw new HttpError(400, 'Bad request: Not a valid auto-dag-data IPLD node')
   }
-  return ipldMetadata.linkDepth === 0 && ipldMetadata.data
-    ? Buffer.from(ipldMetadata.data)
-    : null
+  return Buffer.from(ipldMetadata.data ?? [])
 }
 
 export const dsnFetcher = {

--- a/services/file-retriever/src/services/fileComposer.ts
+++ b/services/file-retriever/src/services/fileComposer.ts
@@ -1,22 +1,8 @@
 import { dsnFetcher } from './dsnFetcher.js'
 import { forkStream } from '@autonomys/asynchronous'
 import { logger } from '../drivers/logger.js'
-import {
-  createFileCache,
-  defaultMemoryAndSqliteConfig,
-  ensureDirectoryExists,
-  FileResponse,
-} from '@autonomys/file-caching'
-import path from 'path'
-import { config } from '../config.js'
-
-const cache = createFileCache(
-  defaultMemoryAndSqliteConfig({
-    dirname: ensureDirectoryExists(path.join(config.cacheDir, 'files')),
-    cacheMaxSize: config.cacheMaxSize,
-    cacheTtl: config.cacheTtl,
-  }),
-)
+import { FileResponse } from '@autonomys/file-caching'
+import { cache } from './cache.js'
 
 const get = async (
   cid: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,12 +36,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/asynchronous@npm:^1.4.31, @autonomys/asynchronous@npm:^1.4.35":
+"@autonomys/asynchronous@npm:^1.4.35":
   version: 1.4.35
   resolution: "@autonomys/asynchronous@npm:1.4.35"
   dependencies:
     stream-fork: "npm:^1.0.5"
   checksum: 10c0/493a64e21cc64eca6c252fef68b0de3f7fbccf3428cf0c9d6b74458aa0aff6ca74f139bb9790234a0c5d42d743b8672e10efd15cd567bf2096967fc1434a41c7
+  languageName: node
+  linkType: hard
+
+"@autonomys/asynchronous@npm:^1.4.36":
+  version: 1.4.36
+  resolution: "@autonomys/asynchronous@npm:1.4.36"
+  dependencies:
+    stream-fork: "npm:^1.0.5"
+  checksum: 10c0/7500be44fae992f2a62c79009442b4c88c9539769029eeaef97dcb81668c2f2a684323eb92d393d2ad6543031dfebdfa68eeeb3c896344258b6a9b296dca930c
   languageName: node
   linkType: hard
 
@@ -64,7 +73,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@autonomys/auto-utils@npm:^1.4.31, @autonomys/auto-utils@npm:^1.4.35":
+"@autonomys/auto-dag-data@npm:^1.4.36":
+  version: 1.4.36
+  resolution: "@autonomys/auto-dag-data@npm:1.4.36"
+  dependencies:
+    "@autonomys/asynchronous": "npm:^1.4.36"
+    "@ipld/dag-pb": "npm:^4.1.3"
+    "@peculiar/webcrypto": "npm:^1.5.0"
+    "@webbuf/blake3": "npm:^3.0.26"
+    "@webbuf/fixedbuf": "npm:^3.0.26"
+    "@webbuf/webbuf": "npm:^3.0.26"
+    fflate: "npm:^0.8.2"
+    multiformats: "npm:^13.3.2"
+    protobufjs: "npm:^7.4.0"
+    protons: "npm:^7.6.0"
+    protons-runtime: "npm:^5.5.0"
+  checksum: 10c0/732cb0913faf00dfc702a6ec2a2107646ba4b9a9c95c7c47f3682efb0e5eb030f70f6be2aa5e282a5f81a5fc3d52bfff9c2e63ac01ff40a119efb0a449ce9c65
+  languageName: node
+  linkType: hard
+
+"@autonomys/auto-utils@npm:^1.4.31":
   version: 1.4.35
   resolution: "@autonomys/auto-utils@npm:1.4.35"
   dependencies:
@@ -74,13 +102,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@autonomys/file-caching@npm:^1.4.31":
-  version: 1.4.35
-  resolution: "@autonomys/file-caching@npm:1.4.35"
+"@autonomys/auto-utils@npm:^1.4.36":
+  version: 1.4.36
+  resolution: "@autonomys/auto-utils@npm:1.4.36"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.4.35"
-    "@autonomys/auto-dag-data": "npm:^1.4.35"
-    "@autonomys/auto-utils": "npm:^1.4.35"
+    "@polkadot/api": "npm:^15.8.1"
+    "@polkadot/extension-dapp": "npm:^0.58.6"
+  checksum: 10c0/cf4e8426ce75bfa9fc3064cdf528d8ecfcd6b264fc7ff6f497fbe4ce1f8875c8c9e2e85293067f26645c9d260e61b897fe522d8fd327e5fd3a76300c94bd4748
+  languageName: node
+  linkType: hard
+
+"@autonomys/file-caching@npm:^1.4.36":
+  version: 1.4.36
+  resolution: "@autonomys/file-caching@npm:1.4.36"
+  dependencies:
+    "@autonomys/asynchronous": "npm:^1.4.36"
+    "@autonomys/auto-dag-data": "npm:^1.4.36"
+    "@autonomys/auto-utils": "npm:^1.4.36"
     "@keyvhq/sqlite": "npm:^2.1.7"
     cache-manager: "npm:^6.4.2"
     jszip: "npm:^3.10.1"
@@ -90,7 +128,7 @@ __metadata:
     stream: "npm:^0.0.3"
     uuid: "npm:^11.1.0"
     zod: "npm:^3.24.2"
-  checksum: 10c0/f632ab182dc8bf5d54ec01a96a00a5aac67a45ec6408a3578687cfaf0007266bb17abe39b1c63a0a3b5382d905da0fd5e1ca59a577116ce3934bbfc50ba56a79
+  checksum: 10c0/1b2b7d0fd3927c9cba7b4bd6be9b480ee69c7a350a41403ec72ae8411966cfe93c33b6ba67a6b248fb1922cd4f62dd3e10576ea4f3b3ac1d6ff9a83fe7145fad
   languageName: node
   linkType: hard
 
@@ -4720,10 +4758,10 @@ __metadata:
   resolution: "file-retriever@workspace:services/file-retriever"
   dependencies:
     "@auto-files/rpc-apis": "workspace:*"
-    "@autonomys/asynchronous": "npm:^1.4.31"
+    "@autonomys/asynchronous": "npm:^1.4.36"
     "@autonomys/auto-dag-data": "npm:^1.4.31"
     "@autonomys/auto-utils": "npm:^1.4.31"
-    "@autonomys/file-caching": "npm:^1.4.31"
+    "@autonomys/file-caching": "npm:^1.4.36"
     "@autonomys/rpc": "npm:^1.4.31"
     "@ipld/dag-pb": "npm:^4.1.3"
     "@keyvhq/core": "npm:^2.1.1"


### PR DESCRIPTION
Problem: 

For the download of big files that are not present in the files gateway cache the endpoint `GET /files/:cid` is not useful since it gets timed out via Cloudfare and the UX is bad. 

Solution:

Implement partial downloads were the user would be incrementally ask for nodes starting with index=0 until it receives a empty Buffer indicating that the file has been downloaded completely. 