### PR TITLE
Populate file cache using nodes cache when download finished

### DIFF
--- a/services/file-retriever/src/http/controllers/file.ts
+++ b/services/file-retriever/src/http/controllers/file.ts
@@ -8,6 +8,7 @@ import { uniqueHeaderValue } from '../../utils/http.js'
 import { HttpError } from '../middlewares/error.js'
 import { dsnFetcher } from '../../services/dsnFetcher.js'
 import { safeIPLDDecode } from '../../utils/dagData.js'
+import { fileCache } from '../../services/cache.js'
 
 const fileRouter = Router()
 
@@ -28,6 +29,20 @@ fileRouter.get(
     } else {
       res.sendStatus(404)
     }
+  }),
+)
+
+fileRouter.get(
+  '/:cid/status',
+  authMiddleware,
+  asyncSafeHandler(async (req, res) => {
+    const cid = req.params.cid
+
+    const isCached = await fileCache.has(cid)
+
+    res.status(200).json({
+      isCached,
+    })
   }),
 )
 


### PR DESCRIPTION
**Problem:**

When a file is cached by nodes the download bandwidth is significantly lower that using file system streams. 

**Solution:**

- Populate file cache composing cached nodes
- Add a `GET /files/:cid/status` for controlling cache status