### PR TITLE
Update to not distribute object mappings until the whole segment is archived

### DIFF
--- a/common/rpc-apis/package.json
+++ b/common/rpc-apis/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "@auto-files/models": "workspace:*",
-    "@autonomys/rpc": "^1.4.31",
+    "@autonomys/rpc": "^1.5.4",
     "zod": "^3.24.2"
   },
   "exports": {

--- a/common/rpc-apis/package.json
+++ b/common/rpc-apis/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "@auto-files/models": "workspace:*",
-    "@autonomys/rpc": "^1.5.4",
+    "@autonomys/rpc": "^1.5.6",
     "zod": "^3.24.2"
   },
   "exports": {

--- a/common/rpc-apis/src/objectMappingIndexer.ts
+++ b/common/rpc-apis/src/objectMappingIndexer.ts
@@ -1,6 +1,5 @@
 /* eslint-disable camelcase */
 import { defineUnvalidatedType, createApiDefinition } from '@autonomys/rpc'
-import { z } from 'zod'
 import { ObjectMapping } from '@auto-files/models'
 
 export const ObjectMappingIndexerRPCApi = createApiDefinition({
@@ -8,44 +7,27 @@ export const ObjectMappingIndexerRPCApi = createApiDefinition({
     // Subscribes to live object mappings
     subscribe_object_mappings: {
       params: defineUnvalidatedType<void>(),
-      returns: z.object({
-        subscriptionId: z.string(),
-      }),
+      returns: defineUnvalidatedType<{ subscriptionId: string }>(),
     },
     // Unsubscribes from live object mappings
     unsubscribe_object_mappings: {
-      params: z.object({
-        subscriptionId: z.string(),
-      }),
-      returns: z.object({
-        success: z.boolean(),
-      }),
+      params: defineUnvalidatedType<{ subscriptionId: string }>(),
+      returns: defineUnvalidatedType<{ success: boolean }>(),
     },
     // Subscribes to past object mappings
     subscribe_recover_object_mappings: {
-      params: z.object({
-        pieceIndex: z.number(),
-        step: z.number().optional(),
-      }),
-      returns: z.object({
-        subscriptionId: z.string(),
-      }),
+      params: defineUnvalidatedType<{ pieceIndex: number; step?: number }>(),
+      returns: defineUnvalidatedType<{ subscriptionId: string }>(),
     },
     // Unsubscribes from the recover object mappings
     unsubscribe_recover_object_mappings: {
-      params: z.object({
-        subscriptionId: z.string(),
-      }),
-      returns: z.object({
-        success: z.boolean(),
-      }),
+      params: defineUnvalidatedType<{ subscriptionId: string }>(),
+      returns: defineUnvalidatedType<{ success: boolean }>(),
     },
     // Retrieves the object mappings for the given hashes
     get_object_mappings: {
-      params: z.object({
-        hashes: z.array(z.string()),
-      }),
-      returns: z.array(z.tuple([z.string(), z.number(), z.number()])),
+      params: defineUnvalidatedType<{ hashes: string[] }>(),
+      returns: defineUnvalidatedType<Array<[string, number, number]>>(),
     },
   },
   notifications: {

--- a/common/rpc-apis/src/subspaceObjectListener.ts
+++ b/common/rpc-apis/src/subspaceObjectListener.ts
@@ -1,6 +1,5 @@
 /* eslint-disable camelcase */
 import { ObjectMappingListEntry } from '@auto-files/models'
-import { z } from 'zod'
 import { createApiDefinition, defineUnvalidatedType } from '@autonomys/rpc'
 
 type SubscriptionResult<T> = {
@@ -8,19 +7,17 @@ type SubscriptionResult<T> = {
   result: T
 }
 
-const ArchivedSegmentHeaderValidator = z.object({
-  v0: z.object({
-    segmentIndex: z.number(),
-    segmentCommitment: z.string(),
-    prevSegmentHeaderHash: z.string(),
-    lastArchivedBlock: z.object({
-      number: z.number(),
-      archivedProgress: z.object({
-        partial: z.number(),
-      }),
-    }),
-  }),
-})
+type ArchivedSegmentHeader = {
+  v0: {
+    segmentIndex: number
+    segmentCommitment: string
+    prevSegmentHeaderHash: string
+    lastArchivedBlock: {
+      number: number
+      archivedProgress: { partial: number }
+    }
+  }
+}
 
 export const SubspaceRPCApi = createApiDefinition({
   methods: {
@@ -34,7 +31,7 @@ export const SubspaceRPCApi = createApiDefinition({
     },
     subspace_lastSegmentHeaders: {
       params: defineUnvalidatedType<[number]>(),
-      returns: z.array(ArchivedSegmentHeaderValidator),
+      returns: defineUnvalidatedType<ArchivedSegmentHeader[]>(),
     },
   },
   notifications: {
@@ -43,7 +40,7 @@ export const SubspaceRPCApi = createApiDefinition({
         defineUnvalidatedType<SubscriptionResult<ObjectMappingListEntry>>(),
     },
     subspace_archived_segment_header: {
-      content: ArchivedSegmentHeaderValidator,
+      content: defineUnvalidatedType<ArchivedSegmentHeader>(),
     },
   },
 })

--- a/common/rpc-apis/src/subspaceObjectListener.ts
+++ b/common/rpc-apis/src/subspaceObjectListener.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import { ObjectMappingListEntry } from '@auto-files/models'
+import { z } from 'zod'
 import { createApiDefinition, defineUnvalidatedType } from '@autonomys/rpc'
 
 type SubscriptionResult<T> = {
@@ -7,17 +8,42 @@ type SubscriptionResult<T> = {
   result: T
 }
 
-export const SubspaceObjectListenerAPI = createApiDefinition({
+const ArchivedSegmentHeaderValidator = z.object({
+  v0: z.object({
+    segmentIndex: z.number(),
+    segmentCommitment: z.string(),
+    prevSegmentHeaderHash: z.string(),
+    lastArchivedBlock: z.object({
+      number: z.number(),
+      archivedProgress: z.object({
+        partial: z.number(),
+      }),
+    }),
+  }),
+})
+
+export const SubspaceRPCApi = createApiDefinition({
   methods: {
     subspace_subscribeObjectMappings: {
       params: defineUnvalidatedType<void>(),
       returns: defineUnvalidatedType<string>(),
+    },
+    subspace_subscribeArchivedSegmentHeader: {
+      params: defineUnvalidatedType<void>(),
+      returns: defineUnvalidatedType<string>(),
+    },
+    subspace_lastSegmentHeaders: {
+      params: defineUnvalidatedType<[number]>(),
+      returns: z.array(ArchivedSegmentHeaderValidator),
     },
   },
   notifications: {
     subspace_object_mappings: {
       content:
         defineUnvalidatedType<SubscriptionResult<ObjectMappingListEntry>>(),
+    },
+    subspace_archived_segment_header: {
+      content: ArchivedSegmentHeaderValidator,
     },
   },
 })

--- a/services/object-mapping-indexer/.env.test
+++ b/services/object-mapping-indexer/.env.test
@@ -1,0 +1,1 @@
+LOG_LEVEL=error

--- a/services/object-mapping-indexer/__tests__/objectMappingListener.spec.ts
+++ b/services/object-mapping-indexer/__tests__/objectMappingListener.spec.ts
@@ -1,0 +1,67 @@
+/* eslint-disable camelcase */
+import { jest } from '@jest/globals'
+import { SubspaceRPCApi } from '@auto-files/rpc-apis'
+import { logger } from '../src/drivers/logger.js'
+import { createObjectMappingListener } from '../src/services/objectMappingListener/index.js'
+import { createMockConnection } from '@autonomys/rpc'
+import { objectMappingUseCase } from '../src/useCases/objectMapping.js'
+
+let client: ReturnType<typeof SubspaceRPCApi.createMockServerClient> | undefined
+
+describe('Object Mapping Listener', () => {
+  it('should save received object mappings', async () => {
+    jest.spyOn(SubspaceRPCApi, 'createClient').mockImplementation((params) => {
+      logger.info(
+        'Creating Subspace RPC client (mocked for object mapping listener)',
+      )
+      logger.info(`Callbacks: onEveryOpen=${!!params.callbacks?.onEveryOpen}`)
+      logger.info(
+        `Callbacks: onReconnection=${!!params.callbacks?.onReconnection}`,
+      )
+      client = SubspaceRPCApi.createMockServerClient({
+        handlers: {
+          subspace_subscribeObjectMappings: () => '123',
+          subspace_subscribeArchivedSegmentHeader: () => '456',
+          subspace_lastSegmentHeaders: () => [],
+        },
+        callbacks: {
+          onEveryOpen: params.callbacks?.onEveryOpen,
+          onReconnection: params.callbacks?.onReconnection,
+        },
+      })
+
+      return client
+    })
+
+    const processObjectMappingSpy = jest.spyOn(
+      objectMappingUseCase,
+      'processObjectMapping',
+    )
+
+    const objectMappingListener = createObjectMappingListener()
+    objectMappingListener.start()
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    if (!client) {
+      throw new Error('Client not initialized')
+    }
+
+    client.notificationClient.subspace_object_mappings(createMockConnection(), {
+      result: {
+        v0: {
+          objects: [['0x123', 1, 2]],
+        },
+        blockNumber: 0,
+      },
+      subscriptionId: '123',
+    })
+
+    expect(processObjectMappingSpy).toHaveBeenCalledWith({
+      blockNumber: 0,
+      v0: {
+        objects: [['0x123', 1, 2]],
+      },
+    })
+  })
+})

--- a/services/object-mapping-indexer/__tests__/objectMappingListener.spec.ts
+++ b/services/object-mapping-indexer/__tests__/objectMappingListener.spec.ts
@@ -3,7 +3,7 @@ import { jest } from '@jest/globals'
 import { SubspaceRPCApi } from '@auto-files/rpc-apis'
 import { logger } from '../src/drivers/logger.js'
 import { createObjectMappingListener } from '../src/services/objectMappingListener/index.js'
-import { createMockConnection } from '@autonomys/rpc'
+import { createMockConnection } from './utils.js'
 import { objectMappingUseCase } from '../src/useCases/objectMapping.js'
 
 let client: ReturnType<typeof SubspaceRPCApi.createMockServerClient> | undefined

--- a/services/object-mapping-indexer/__tests__/objectMappingRouter.spec.ts
+++ b/services/object-mapping-indexer/__tests__/objectMappingRouter.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { jest } from '@jest/globals'
-import { createMockConnection } from '@autonomys/rpc'
+import { createMockConnection } from './utils.js'
 import { logger } from '../src/drivers/logger.js'
 import { objectMappingRouter } from '../src/services/objectMappingRouter/index.js'
 import { segmentUseCase } from '../src/useCases/segment.js'

--- a/services/object-mapping-indexer/__tests__/objectMappingRouter.spec.ts
+++ b/services/object-mapping-indexer/__tests__/objectMappingRouter.spec.ts
@@ -1,0 +1,136 @@
+/* eslint-disable camelcase */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { jest } from '@jest/globals'
+import { createMockConnection } from '@autonomys/rpc'
+import { logger } from '../src/drivers/logger.js'
+import { objectMappingRouter } from '../src/services/objectMappingRouter/index.js'
+import { segmentUseCase } from '../src/useCases/segment.js'
+import { SubspaceRPCApi } from '@auto-files/rpc-apis'
+import { objectMappingUseCase } from '../src/useCases/objectMapping.js'
+
+let client: ReturnType<typeof SubspaceRPCApi.createMockServerClient>
+
+const mockSubscribeToArchivedSegmentHeader = () => {
+  jest
+    .spyOn(segmentUseCase, 'subscribeToArchivedSegmentHeader')
+    .mockImplementation(async (onArchivedSegmentHeader) => {
+      client = SubspaceRPCApi.createMockServerClient({
+        callbacks: {
+          onEveryOpen: async () => {
+            const lastSegmentIndex = await segmentUseCase.getLastSegment()
+            // emit the last segment index just in case during a reconnection
+            // a segment was archived, client should ignore duplicates
+            onArchivedSegmentHeader?.(lastSegmentIndex)
+
+            logger.info(
+              `Subscribing to archived segment headers (lastSegmentIndex=${lastSegmentIndex})`,
+            )
+            // triggers a new subscription to archived segment headers
+            // ignores subscriptionId and processed events by name
+            // using client.onNotification('subspace_archived_segment_header')
+            client.api.subspace_subscribeArchivedSegmentHeader()
+            client.onNotification(
+              'subspace_archived_segment_header',
+              (event) => {
+                logger.info(
+                  `Processing archived segment header (segmentIndex=${event.v0.segmentIndex})`,
+                )
+                logger.debug(
+                  `Archived segment header: ${JSON.stringify(event)}`,
+                )
+                onArchivedSegmentHeader?.(event.v0.segmentIndex)
+              },
+            )
+          },
+        },
+        handlers: {
+          subspace_lastSegmentHeaders: async () => [],
+          subspace_subscribeObjectMappings: () => '123',
+          subspace_subscribeArchivedSegmentHeader: () => '456',
+        },
+      })
+    })
+}
+
+jest.mock('../src/rpc/server.js', () => ({
+  server: { notificationClient: { object_mapping_list: jest.fn() } },
+}))
+
+describe('Object Mapping Router', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+    jest.restoreAllMocks()
+    objectMappingRouter.close()
+  })
+
+  it('should be initialized correctly', async () => {
+    jest.spyOn(segmentUseCase, 'getLastSegment').mockResolvedValue(-1)
+    mockSubscribeToArchivedSegmentHeader()
+
+    await objectMappingRouter.init()
+
+    expect(objectMappingRouter.getState().lastRealtimeSegmentIndex).toBe(-1)
+  })
+
+  it('should fetch object mappings for last segment', async () => {
+    jest.spyOn(segmentUseCase, 'getLastSegment').mockResolvedValue(-1)
+    const getObjectByPieceIndexRangeSpy = jest
+      .spyOn(objectMappingUseCase, 'getObjectByPieceIndexRange')
+      .mockResolvedValue([])
+    mockSubscribeToArchivedSegmentHeader()
+
+    await objectMappingRouter.init()
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    expect(objectMappingRouter.getState().lastRealtimeSegmentIndex).toBe(-1)
+
+    const connection = createMockConnection()
+
+    client.notificationClient.subspace_archived_segment_header(connection, {
+      v0: {
+        segmentIndex: 0,
+        segmentCommitment: '0x123',
+        prevSegmentHeaderHash: '0x456',
+        lastArchivedBlock: {
+          number: 0,
+          archivedProgress: { partial: 0 },
+        },
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(objectMappingRouter.getState().lastRealtimeSegmentIndex).toBe(0)
+    expect(getObjectByPieceIndexRangeSpy).toHaveBeenCalledWith(0, 255)
+  })
+
+  it('should fetch object mappings for last two segments when event is missed', async () => {
+    jest.spyOn(segmentUseCase, 'getLastSegment').mockResolvedValue(-1)
+    const getObjectByPieceIndexRangeSpy = jest
+      .spyOn(objectMappingUseCase, 'getObjectByPieceIndexRange')
+      .mockResolvedValue([])
+    mockSubscribeToArchivedSegmentHeader()
+
+    await objectMappingRouter.init()
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    expect(objectMappingRouter.getState().lastRealtimeSegmentIndex).toBe(-1)
+
+    const connection = createMockConnection()
+
+    client.notificationClient.subspace_archived_segment_header(connection, {
+      v0: {
+        segmentIndex: 1,
+        segmentCommitment: '0x123',
+        prevSegmentHeaderHash: '0x456',
+        lastArchivedBlock: {
+          number: 0,
+          archivedProgress: { partial: 0 },
+        },
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(objectMappingRouter.getState().lastRealtimeSegmentIndex).toBe(1)
+    expect(getObjectByPieceIndexRangeSpy).toHaveBeenCalledWith(0, 511)
+  })
+})

--- a/services/object-mapping-indexer/__tests__/segment.spec.ts
+++ b/services/object-mapping-indexer/__tests__/segment.spec.ts
@@ -1,0 +1,15 @@
+import { segmentUseCase } from '../src/useCases/segment.js'
+
+describe('Segment Use Cases', () => {
+  it('should get the piece index range by segment', () => {
+    expect(segmentUseCase.getPieceIndexRangeBySegment(0)).toEqual([0, 255])
+    expect(segmentUseCase.getPieceIndexRangeBySegment(1)).toEqual([256, 511])
+  })
+
+  it('should get the segment by piece index', () => {
+    expect(segmentUseCase.getSegmentByPieceIndex(0)).toEqual(0)
+    expect(segmentUseCase.getSegmentByPieceIndex(1)).toEqual(0)
+    expect(segmentUseCase.getSegmentByPieceIndex(255)).toEqual(0)
+    expect(segmentUseCase.getSegmentByPieceIndex(256)).toEqual(1)
+  })
+})

--- a/services/object-mapping-indexer/__tests__/test-setup.ts
+++ b/services/object-mapping-indexer/__tests__/test-setup.ts
@@ -1,0 +1,3 @@
+import * as dotenv from 'dotenv'
+
+dotenv.config({ path: './.env.test' })

--- a/services/object-mapping-indexer/__tests__/utils.ts
+++ b/services/object-mapping-indexer/__tests__/utils.ts
@@ -1,0 +1,4 @@
+import Websocket from 'websocket'
+
+export const createMockConnection = (): Websocket.connection =>
+  null as unknown as Websocket.connection

--- a/services/object-mapping-indexer/jest.config.ts
+++ b/services/object-mapping-indexer/jest.config.ts
@@ -1,0 +1,25 @@
+const { createDefaultEsmPreset } = require('ts-jest')
+
+module.exports = {
+  ...createDefaultEsmPreset(),
+  testMatch: ['**/__tests__/**/*.spec.ts'],
+  setupFiles: ['./__tests__/test-setup.ts'],
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  coveragePathIgnorePatterns: [
+    './__tests__/utils/',
+    './node_modules/',
+    './migrations/',
+  ],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: 'tsconfig.test.json',
+      },
+    ],
+  },
+}

--- a/services/object-mapping-indexer/package.json
+++ b/services/object-mapping-indexer/package.json
@@ -10,7 +10,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "node --loader ts-node/esm",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --runInBand --forceExit"
   },
   "license": "MIT",
   "dependencies": {
@@ -47,6 +48,7 @@
     "eslint-plugin-eslint-plugin": "^6.3.1",
     "eslint-plugin-prettier": "^5.2.1",
     "prettier": "^3.3.3",
+    "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"
   }

--- a/services/object-mapping-indexer/src/listeners.ts
+++ b/services/object-mapping-indexer/src/listeners.ts
@@ -1,3 +1,5 @@
 import { createObjectMappingListener } from './services/objectMappingListener/index.js'
+import { objectMappingRouter } from './services/objectMappingRouter/index.js'
 
+objectMappingRouter.init()
 createObjectMappingListener().start()

--- a/services/object-mapping-indexer/src/repositories/objectMapping.ts
+++ b/services/object-mapping-indexer/src/repositories/objectMapping.ts
@@ -67,7 +67,7 @@ const getByPieceIndexRange = async (min: number, max: number) => {
   const db = await getDatabase()
 
   const result = await db.query<DBObjectMapping>(
-    'SELECT * FROM object_mappings WHERE "pieceIndex" >= $1 AND "pieceIndex" < $2',
+    'SELECT * FROM object_mappings WHERE "pieceIndex" >= $1 AND "pieceIndex" <= $2',
     [min, max],
   )
 

--- a/services/object-mapping-indexer/src/services/objectMappingListener/index.ts
+++ b/services/object-mapping-indexer/src/services/objectMappingListener/index.ts
@@ -1,7 +1,7 @@
 import { logger } from '../../drivers/logger.js'
 import { objectMappingUseCase } from '../../useCases/objectMapping.js'
 import { ObjectMappingListener } from './types.js'
-import { SubspaceObjectListenerAPI } from '@auto-files/rpc-apis'
+import { SubspaceRPCApi } from '@auto-files/rpc-apis'
 import { config } from '../../config.js'
 
 export const createObjectMappingListener = (): ObjectMappingListener => {
@@ -20,7 +20,7 @@ export const createObjectMappingListener = (): ObjectMappingListener => {
         })
       }
 
-      const client = SubspaceObjectListenerAPI.createClient({
+      const client = SubspaceRPCApi.createClient({
         endpoint: config.nodeRpcUrl,
         reconnectInterval: 60_000,
         callbacks: {

--- a/services/object-mapping-indexer/src/services/objectMappingListener/index.ts
+++ b/services/object-mapping-indexer/src/services/objectMappingListener/index.ts
@@ -13,7 +13,7 @@ export const createObjectMappingListener = (): ObjectMappingListener => {
 
         client.onNotification('subspace_object_mappings', async (event) => {
           logger.info(
-            `Processing object mapping (blockNumber=${event.result.blockNumber})`,
+            `Processing object mapping (blockNumber=${event.result.v0})`,
           )
           logger.debug(`Object mapping: ${JSON.stringify(event)}`)
           await objectMappingUseCase.processObjectMapping(event.result)

--- a/services/object-mapping-indexer/src/services/objectMappingRouter/index.ts
+++ b/services/object-mapping-indexer/src/services/objectMappingRouter/index.ts
@@ -137,7 +137,8 @@ const emitRecoverObjectMappings = async () => {
 
   const promises = recovering.map(
     async ([subscriptionId, { connection, pieceIndex, step }]) => {
-      const upperLimit = getUpperLimit(pieceIndex + step)
+      const upperPieceIndex = pieceIndex + step
+      const upperLimit = getUpperLimit(upperPieceIndex)
       const result = await objectMappingUseCase.getObjectByPieceIndexRange(
         pieceIndex,
         upperLimit,
@@ -149,7 +150,7 @@ const emitRecoverObjectMappings = async () => {
         step,
       })
 
-      const hasReachedLastSegment = pieceIndex !== upperLimit
+      const hasReachedLastSegment = upperPieceIndex > upperLimit
       if (hasReachedLastSegment) {
         unsubscribeRecoverObjectMappings(subscriptionId)
         subscribeObjectMappings(connection, subscriptionId)

--- a/services/object-mapping-indexer/src/services/objectMappingRouter/index.ts
+++ b/services/object-mapping-indexer/src/services/objectMappingRouter/index.ts
@@ -55,12 +55,20 @@ const emitObjectMappings = async (segmentIndex: number) => {
     return
   }
   state.lastRealtimeSegmentIndex = segmentIndex
-  const [lowerLimit, upperLimit] =
-    segmentUseCase.getPieceIndexRangeBySegment(segmentIndex)
+  const UPPER_LIMIT_RANGE_INDEX = 1
+  const lastUpperLimit = segmentUseCase.getPieceIndexRangeBySegment(
+    state.lastRealtimeSegmentIndex,
+  )[UPPER_LIMIT_RANGE_INDEX]
+  const upperLimit =
+    segmentUseCase.getPieceIndexRangeBySegment(segmentIndex)[
+      UPPER_LIMIT_RANGE_INDEX
+    ]
   const objectMappings = await objectMappingUseCase.getObjectByPieceIndexRange(
-    lowerLimit,
+    lastUpperLimit + 1,
     upperLimit,
   )
+
+  state.lastRealtimeSegmentIndex = segmentIndex
 
   Array.from(state.objectMappingsSubscriptions.entries()).forEach(
     ([subscriptionId, connection]) => {

--- a/services/object-mapping-indexer/src/services/objectMappingRouter/index.ts
+++ b/services/object-mapping-indexer/src/services/objectMappingRouter/index.ts
@@ -54,7 +54,6 @@ const emitObjectMappings = async (segmentIndex: number) => {
   if (segmentIndex <= state.lastRealtimeSegmentIndex) {
     return
   }
-  state.lastRealtimeSegmentIndex = segmentIndex
   const UPPER_LIMIT_RANGE_INDEX = 1
   const lastUpperLimit = segmentUseCase.getPieceIndexRangeBySegment(
     state.lastRealtimeSegmentIndex,

--- a/services/object-mapping-indexer/src/useCases/objectMapping.ts
+++ b/services/object-mapping-indexer/src/useCases/objectMapping.ts
@@ -4,7 +4,6 @@ import {
   ObjectMappingListEntry,
 } from '@auto-files/models'
 import { objectMappingRepository } from '../repositories/objectMapping.js'
-import { objectMappingRouter } from '../services/objectMappingRouter/index.js'
 import { blake3HashFromCid, stringToCid } from '@autonomys/auto-dag-data'
 
 const processObjectMapping = async (event: ObjectMappingListEntry) => {
@@ -18,8 +17,6 @@ const processObjectMapping = async (event: ObjectMappingListEntry) => {
       })),
     ),
   ])
-
-  objectMappingRouter.emitObjectMappings(event)
 }
 
 const getObject = async (hash: string): Promise<GlobalObjectMapping> => {
@@ -51,13 +48,13 @@ const getObjectByPieceIndex = async (
   return objectMappings.map((e) => [e.hash, e.pieceIndex, e.pieceOffset])
 }
 
-const getObjectByPieceIndexAndStep = async (
+const getObjectByPieceIndexRange = async (
   pieceIndex: number,
-  step: number,
+  upperLimit: number,
 ): Promise<ObjectMapping[]> => {
   const objectMappings = await objectMappingRepository.getByPieceIndexRange(
     pieceIndex,
-    pieceIndex + step,
+    pieceIndex + upperLimit,
   )
 
   return objectMappings.map((e) => [e.hash, e.pieceIndex, e.pieceOffset])
@@ -112,7 +109,7 @@ export const objectMappingUseCase = {
   getObject,
   getObjectByPieceIndex,
   getObjectByBlock,
-  getObjectByPieceIndexAndStep,
+  getObjectByPieceIndexRange,
   getObjectMappings,
   getObjectByCid,
 }

--- a/services/object-mapping-indexer/src/useCases/segment.ts
+++ b/services/object-mapping-indexer/src/useCases/segment.ts
@@ -1,0 +1,75 @@
+import { SubspaceObjectListenerAPI } from '@auto-files/rpc-apis'
+import { config } from '../config.js'
+import { logger } from '../drivers/logger.js'
+
+const getLastSegment = async () => {
+  const client = SubspaceObjectListenerAPI.createHttpClient(
+    config.nodeRpcUrl.replace('ws', 'http'),
+  )
+
+  const lastSegmentsResult = await client.subspace_lastSegmentHeaders([1])
+
+  if (lastSegmentsResult.length === 0 || lastSegmentsResult[0] === undefined) {
+    logger.error(
+      `No last segment found: ${lastSegmentsResult ? JSON.stringify(lastSegmentsResult) : '<undefined>'}`,
+    )
+    throw new Error('No last segment found')
+  }
+
+  logger.debug(`Last segment index: ${lastSegmentsResult[0].v0.segmentIndex}`)
+
+  return lastSegmentsResult[0].v0.segmentIndex
+}
+
+const subscribeToArchivedSegmentHeader = async (
+  onArchivedSegmentHeader?: (segmentIndex: number) => void,
+) => {
+  const client = SubspaceObjectListenerAPI.createClient({
+    endpoint: config.nodeRpcUrl,
+    callbacks: {
+      onEveryOpen: async () => {
+        const lastSegmentIndex = await getLastSegment()
+        // emit the last segment index just in case during a reconnection
+        // a segment was archived, client should ignore duplicates
+        onArchivedSegmentHeader?.(lastSegmentIndex)
+
+        logger.info(
+          `Subscribing to archived segment headers (lastSegmentIndex=${lastSegmentIndex})`,
+        )
+        // triggers a new subscription to archived segment headers
+        // ignores subscriptionId and processed events by name
+        // using client.onNotification('subspace_archived_segment_header')
+        client.api.subspace_subscribeArchivedSegmentHeader()
+        client.onNotification('subspace_archived_segment_header', (event) => {
+          logger.info(
+            `Processing archived segment header (segmentIndex=${event.v0.segmentIndex})`,
+          )
+          logger.debug(`Archived segment header: ${JSON.stringify(event)}`)
+          onArchivedSegmentHeader?.(event.v0.segmentIndex)
+        })
+      },
+    },
+  })
+}
+
+const getSegmentByPieceIndex = (pieceIndex: number) => {
+  const RAW_RECORDS = 128
+  const ERASURE_ENCODE_FACTOR = 2
+  return Math.ceil(pieceIndex / (RAW_RECORDS * ERASURE_ENCODE_FACTOR))
+}
+
+const getPieceIndexRangeBySegment = (segmentIndex: number) => {
+  const RAW_RECORDS = 128
+  const ERASURE_ENCODE_FACTOR = 2
+  return [
+    segmentIndex * RAW_RECORDS * ERASURE_ENCODE_FACTOR,
+    (segmentIndex + 1) * RAW_RECORDS * ERASURE_ENCODE_FACTOR - 1,
+  ]
+}
+
+export const segmentUseCase = {
+  getLastSegment,
+  subscribeToArchivedSegmentHeader,
+  getSegmentByPieceIndex,
+  getPieceIndexRangeBySegment,
+}

--- a/services/object-mapping-indexer/src/useCases/segment.ts
+++ b/services/object-mapping-indexer/src/useCases/segment.ts
@@ -55,7 +55,7 @@ const subscribeToArchivedSegmentHeader = async (
 const getSegmentByPieceIndex = (pieceIndex: number) => {
   const RAW_RECORDS = 128
   const ERASURE_ENCODE_FACTOR = 2
-  return Math.ceil(pieceIndex / (RAW_RECORDS * ERASURE_ENCODE_FACTOR))
+  return Math.floor(pieceIndex / (RAW_RECORDS * ERASURE_ENCODE_FACTOR))
 }
 
 const getPieceIndexRangeBySegment = (segmentIndex: number) => {

--- a/services/object-mapping-indexer/tsconfig.test.json
+++ b/services/object-mapping-indexer/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "rootDir": "."
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ __metadata:
   resolution: "@auto-files/rpc-apis@workspace:common/rpc-apis"
   dependencies:
     "@auto-files/models": "workspace:*"
-    "@autonomys/rpc": "npm:^1.5.4"
+    "@autonomys/rpc": "npm:^1.5.6"
     typescript: "npm:^5.6.3"
     zod: "npm:^3.24.2"
   languageName: unknown
@@ -142,13 +142,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@autonomys/rpc@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "@autonomys/rpc@npm:1.5.4"
+"@autonomys/rpc@npm:^1.5.6":
+  version: 1.5.6
+  resolution: "@autonomys/rpc@npm:1.5.6"
   dependencies:
     websocket: "npm:^1.0.35"
     zod: "npm:^3.24.2"
-  checksum: 10c0/fc2ed54a6726c5b368e1634b5c905666f69723ad11bbf2d70dbcd35ef967043d942b45e09cdf79140fd3910f18c633e9f6e6fd12272bfa87e4bf6de8b3a774ea
+  checksum: 10c0/07dfde7a28736421ccb21748b887b98060e50d2614e4ab0df8b33492b67bf6ac67a88a1a5451bc0759f5e77564a4045c4c671960eb3d6dfaf4295a4224f8faf7
   languageName: node
   linkType: hard
 
@@ -7370,6 +7370,7 @@ __metadata:
     pg: "npm:^8.13.1"
     pg-format: "npm:^1.0.4"
     prettier: "npm:^3.3.3"
+    ts-jest: "npm:^29.4.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.6.3"
     uuid: "npm:^11.0.3"
@@ -9178,6 +9179,46 @@ __metadata:
   bin:
     ts-jest: cli.js
   checksum: 10c0/68ed5abbbdb16ff8a9df2ba7ebb8e19ea4fffe87db7e0b59d842d674e7935af8b375b51a69c2cc9215ef22a6325a9f99b80ab97f5c300c30910695000e3bfeee
+  languageName: node
+  linkType: hard
+
+"ts-jest@npm:^29.4.0":
+  version: 29.4.0
+  resolution: "ts-jest@npm:29.4.0"
+  dependencies:
+    bs-logger: "npm:^0.2.6"
+    ejs: "npm:^3.1.10"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    json5: "npm:^2.2.3"
+    lodash.memoize: "npm:^4.1.2"
+    make-error: "npm:^1.3.6"
+    semver: "npm:^7.7.2"
+    type-fest: "npm:^4.41.0"
+    yargs-parser: "npm:^21.1.1"
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/transform": ^29.0.0 || ^30.0.0
+    "@jest/types": ^29.0.0 || ^30.0.0
+    babel-jest: ^29.0.0 || ^30.0.0
+    jest: ^29.0.0 || ^30.0.0
+    jest-util: ^29.0.0 || ^30.0.0
+    typescript: ">=4.3 <6"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/transform":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+    jest-util:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: 10c0/c266431200786995b5bd32f8e61f17a564ce231278aace1d98fb0ae670f24013aeea06c90ec6019431e5a6f5e798868785131bef856085c931d193e2efbcea04
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ __metadata:
   resolution: "@auto-files/rpc-apis@workspace:common/rpc-apis"
   dependencies:
     "@auto-files/models": "workspace:*"
-    "@autonomys/rpc": "npm:^1.4.31"
+    "@autonomys/rpc": "npm:^1.5.4"
     typescript: "npm:^5.6.3"
     zod: "npm:^3.24.2"
   languageName: unknown
@@ -139,6 +139,16 @@ __metadata:
     websocket: "npm:^1.0.35"
     zod: "npm:^3.24.2"
   checksum: 10c0/18b22b8f9bd91785b77093f8e591fa275d15ec09b53bdd47b9d30ff0d0cc3d0210dac16c5455f69f3cba3244cfbe565fddbc53204b74457ae4abfa32e3bd787c
+  languageName: node
+  linkType: hard
+
+"@autonomys/rpc@npm:^1.5.4":
+  version: 1.5.4
+  resolution: "@autonomys/rpc@npm:1.5.4"
+  dependencies:
+    websocket: "npm:^1.0.35"
+    zod: "npm:^3.24.2"
+  checksum: 10c0/fc2ed54a6726c5b368e1634b5c905666f69723ad11bbf2d70dbcd35ef967043d942b45e09cdf79140fd3910f18c633e9f6e6fd12272bfa87e4bf6de8b3a774ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I thought that blocks within the same segment were archived at the same time. But the archiving lifecycle is the following:

> Block created -> Block archived (is encoded within a piece + object mapping emissions) -> Segment completes (starts propagation + within a short delay the pieces within that segment are available)

**What does this PR change?**

Formerly the indexer was subscribed with `subspace_subscribeObjectMappings` and forwarded objects mappings to every realtime subscriber peer.

With this update we don't forward these object mappings directly but we keep track of the current segment index and whenever it's increased we forward all the object mappings within that previous segment. 